### PR TITLE
Add Silo location to ap_check_enough_notes

### DIFF
--- a/n64/src/ap.c
+++ b/n64/src/ap.c
@@ -1189,31 +1189,27 @@ void ap_check_enough_notes(u16 start, u16 end) {
 
   ap.internal_icon = BT_ZOOMBOX_ICON_JAMJARS;
 
+  if (n_unlocks > UNLOCK_LIMIT) {
+    // Too many silos unlocked at the same time.
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK MULTIPLE SILOS!");
+    return;
+  }
+
+  strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK THE ");
+
   if (n_unlocks == 1) {
-    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK THE ");
     strcat(ap.internal_message, names[unlocks[0]]);
     strcat(ap.internal_message, " SILO!");
   }
-  else if (n_unlocks > UNLOCK_LIMIT) {
-    // Too many silos unlocked at the same time.
-    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK MULTIPLE SILOS!");
-  }
   else {
-    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK THE ");
-    for (int i = 0; i < n_unlocks; ++i){
-      bool is_last = (i == n_unlocks - 1);
-      if (is_last) {
-        strcat(ap.internal_message, "AND ");
-      }
-
+    for (int i = 0; i < n_unlocks - 1; ++i){
       strcat(ap.internal_message, names[unlocks[i]]);
-
-      if (is_last) {
-        strcat(ap.internal_message, " SILOS!");
-      } else {
-        strcat(ap.internal_message, ", ");
-      }
+      strcat(ap.internal_message, ", ");
     }
+
+    strcat(ap.internal_message, "AND ");
+    strcat(ap.internal_message, names[unlocks[n_unlocks - 1]]);
+    strcat(ap.internal_message, " SILOS!");
   }
 }
 

--- a/n64/src/ap.c
+++ b/n64/src/ap.c
@@ -1169,7 +1169,7 @@ void ap_check_enough_notes(u16 start, u16 end) {
     "SACK PACK"
   };
 
-  const int UNLOCK_LIMIT = 5;
+  #define UNLOCK_LIMIT 5
   int unlocks[UNLOCK_LIMIT + 1];
   int n_unlocks = 0;
 
@@ -1205,6 +1205,7 @@ void ap_check_enough_notes(u16 start, u16 end) {
     else if (i + 2 == n_unlocks) strcat(ap.internal_message, " AND "); // Second to last
     else strcat(ap.internal_message, ", ");
   }
+  #undef UNLOCK_LIMIT
 }
 
 typedef struct {

--- a/n64/src/ap.c
+++ b/n64/src/ap.c
@@ -1170,20 +1170,21 @@ void ap_check_enough_notes(u16 start, u16 end) {
   };
 
   const int UNLOCK_LIMIT = 5;
-  int unlocks[UNLOCK_LIMIT];
+  int unlocks[UNLOCK_LIMIT + 1];
   int n_unlocks = 0;
 
   for (int i = 0; i < sizeof(ap_memory.pc.settings.silo_requirements)/sizeof(*ap_memory.pc.settings.silo_requirements); i++) {
     u16 amount = ap_memory.pc.settings.silo_requirements[i];
     if (start < amount && end >= amount) {
-      if (n_unlocks < UNLOCK_LIMIT) {
-        unlocks[n_unlocks] = i;
+      unlocks[n_unlocks++] = i;
+
+      if (n_unlocks == UNLOCK_LIMIT + 1) {
+        break;
       }
-      ++n_unlocks;
     }
   }
 
-  if (n_unlocks == 0) {
+  if (!n_unlocks) {
     return;
   }
 
@@ -1191,25 +1192,18 @@ void ap_check_enough_notes(u16 start, u16 end) {
 
   if (n_unlocks > UNLOCK_LIMIT) {
     // Too many silos unlocked at the same time.
-    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK MULTIPLE SILOS!");
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK A LOT OF SILOS!");
     return;
   }
 
   strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK THE ");
 
-  if (n_unlocks == 1) {
-    strcat(ap.internal_message, names[unlocks[0]]);
-    strcat(ap.internal_message, " SILO!");
-  }
-  else {
-    for (int i = 0; i < n_unlocks - 1; ++i){
-      strcat(ap.internal_message, names[unlocks[i]]);
-      strcat(ap.internal_message, ", ");
-    }
-
-    strcat(ap.internal_message, "AND ");
-    strcat(ap.internal_message, names[unlocks[n_unlocks - 1]]);
-    strcat(ap.internal_message, " SILOS!");
+  for (int i = 0; i < n_unlocks; i++) {
+    strcat(ap.internal_message, names[unlocks[i]]);
+    if (n_unlocks == 1) strcat(ap.internal_message, " SILO!"); // Only one
+    else if (i + 1 == n_unlocks) strcat(ap.internal_message, " SILOS!"); // Last one
+    else if (i + 2 == n_unlocks) strcat(ap.internal_message, " AND "); // Second to last
+    else strcat(ap.internal_message, ", ");
   }
 }
 

--- a/n64/src/ap.c
+++ b/n64/src/ap.c
@@ -1141,12 +1141,78 @@ void ap_update() {
 
 void ap_check_enough_notes(u16 start, u16 end) {
   if (start == end || start > end) return;
+
+  const char* names[] = {
+    "EGG AIM",
+    "BREEGULL BLASTER",
+    "GRIP GRAB",
+    "FIRE EGGS",
+    "BILL DRILL",
+    "BEAK BAYONET",
+    "GRENADE EGGS",
+    "SPLIT UP",
+    "PACK WHACK",
+    "AIRBORNE EGG AIMING",
+    "ICE EGGS",
+    "WING WHACK",
+    "SUB-AQUA EGG AIMING",
+    "TALON TORPEDO",
+    "CLOCKWORK KAZOOIE EGGS",
+    "SPRINGY STEP SHOES",
+    "TAXI PACK",
+    "HATCH",
+    "CLAW CLAMBER BOOTS",
+    "SNOOZE PACK",
+    "LEG SPRING",
+    "SHACK PACK",
+    "GLIDE",
+    "SACK PACK"
+  };
+
+  const int UNLOCK_LIMIT = 5;
+  int unlocks[UNLOCK_LIMIT];
+  int n_unlocks = 0;
+
   for (int i = 0; i < sizeof(ap_memory.pc.settings.silo_requirements)/sizeof(*ap_memory.pc.settings.silo_requirements); i++) {
     u16 amount = ap_memory.pc.settings.silo_requirements[i];
     if (start < amount && end >= amount) {
-      ap.internal_icon = BT_ZOOMBOX_ICON_JAMJARS;
-      strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES FOR A NEW MOVE!");
-      break;
+      if (n_unlocks < UNLOCK_LIMIT) {
+        unlocks[n_unlocks] = i;
+      }
+      ++n_unlocks;
+    }
+  }
+
+  if (n_unlocks == 0) {
+    return;
+  }
+
+  ap.internal_icon = BT_ZOOMBOX_ICON_JAMJARS;
+
+  if (n_unlocks == 1) {
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES FOR A NEW MOVE AT ");
+    strcat(ap.internal_message, names[unlocks[0]]);
+    strcat(ap.internal_message, " SILO!");
+  }
+  else if (n_unlocks > UNLOCK_LIMIT) {
+    // Too many silos unlocked at the same time.
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES FOR MULTIPLE NEW MOVES!");
+  }
+  else {
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES FOR NEW MOVES AT ");
+    for (int i = 0; i < n_unlocks; ++i){
+      bool is_last = (i == n_unlocks - 1);
+      if (is_last) {
+        strcat(ap.internal_message, "AND ");
+      }
+
+      strcat(ap.internal_message, names[unlocks[i]]);
+
+      if (is_last) {
+        strcat(ap.internal_message, " SILOS!");
+      } else {
+        strcat(ap.internal_message, ", ");
+      }
     }
   }
 }

--- a/n64/src/ap.c
+++ b/n64/src/ap.c
@@ -1190,16 +1190,16 @@ void ap_check_enough_notes(u16 start, u16 end) {
   ap.internal_icon = BT_ZOOMBOX_ICON_JAMJARS;
 
   if (n_unlocks == 1) {
-    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES FOR A NEW MOVE AT ");
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK THE ");
     strcat(ap.internal_message, names[unlocks[0]]);
     strcat(ap.internal_message, " SILO!");
   }
   else if (n_unlocks > UNLOCK_LIMIT) {
     // Too many silos unlocked at the same time.
-    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES FOR MULTIPLE NEW MOVES!");
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK MULTIPLE SILOS!");
   }
   else {
-    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES FOR NEW MOVES AT ");
+    strcpy(ap.internal_message, "YOU HAVE ENOUGH NOTES TO CHECK THE ");
     for (int i = 0; i < n_unlocks; ++i){
       bool is_last = (i == n_unlocks - 1);
       if (is_last) {


### PR DESCRIPTION
Here we go, this adds the silo location to the message. I've added a hard limit of 5 moves, but we can theoretically go higher as the limit of ~500 characters for a message is lenient enough.

I've tested building by going into n64 folder and running make. Due to some tool issues, couldn't test building outside of n64 folder.

Changes themselves were not tested in ROM. Will do that if this is final and no more changes are needed.