### PR TITLE
Allow green relics requirements to be customizable

### DIFF
--- a/n64/src/ap.c
+++ b/n64/src/ap.c
@@ -905,8 +905,8 @@ void ap_sync_items(u16 type, u8 value) {
     case AP_ITEM_GRRELIC:
       if (value != totals->green_relics) {
         totals->green_relics = value;
-        if(totals->green_relics >= 10 && totals->green_relics <= 20 && bt_current_map == BT_MAP_MT_TARGITZANS_TEMPLE) bt_fn_object_anim(0x2b4, 7, 0);
-        if(totals->green_relics >= 20 && bt_current_map == BT_MAP_MT_TARGITZANS_TEMPLE) bt_fn_object_anim(0x2b4, 7, 1);
+        if(totals->green_relics >= ap_memory.pc.settings.green_relics_chamber_requirement && totals->green_relics <= ap_memory.pc.settings.green_relics_boss_requirement && bt_current_map == BT_MAP_MT_TARGITZANS_TEMPLE) bt_fn_object_anim(0x2b4, 7, 0);
+        if(totals->green_relics >= ap_memory.pc.settings.green_relics_boss_requirement && bt_current_map == BT_MAP_MT_TARGITZANS_TEMPLE) bt_fn_object_anim(0x2b4, 7, 1);
         bt_fn_ui_show_number(BT_UI_NUMBERS_GREEN_SACRED_STATUE, totals->green_relics, 0);
       }
       break;

--- a/n64/src/main.c
+++ b/n64/src/main.c
@@ -1034,6 +1034,7 @@ void pre_object_init(bt_object_t *obj) {
     case BT_OBJ_TEMPLELOBBYDOOR:
     if (!ap_memory.pc.settings.randomize_green_relics) break;
       util_inject(UTIL_INJECT_RAW     , (u32)obj + 0x98, 0, 0);
+      break;
     case BT_OBJ_BEANSTALKSEED:
       if (!ap_memory.pc.settings.randomize_beans) break;
       util_inject(UTIL_INJECT_RAW     , (u32)obj + 0x035C, 0, 0);

--- a/n64/src/main.c
+++ b/n64/src/main.c
@@ -1018,6 +1018,11 @@ void pre_object_init(bt_object_t *obj) {
       if (!ap_memory.pc.settings.randomize_tickets) break;
       util_inject(UTIL_INJECT_RAW     , (u32)obj + 0x0124, 0, 0);
       break;
+    case BT_OBJ_TEMPLEBOSSDOOR:
+      if (!ap_memory.pc.settings.randomize_green_relics) break;
+      util_inject(UTIL_INJECT_RAW     , (u32)obj + 0x009C, (0x24180000 | ap_memory.pc.settings.green_relics_boss_requirement), 0);
+      util_inject(UTIL_INJECT_RAW     , (u32)obj + 0x00A8, (0x240F0000 | ap_memory.pc.settings.green_relics_chamber_requirement), 0);
+      break;
     case BT_OBJ_JADESTATUE:
       if (!ap_memory.pc.settings.randomize_green_relics) break;
       util_inject(UTIL_INJECT_RAW     , (u32)obj + 0x00AC, 0, 0); // called to remove statues when enough flags are set when entering temple

--- a/pc/offsets/show_offsets.c
+++ b/pc/offsets/show_offsets.c
@@ -45,6 +45,8 @@ int main() {
   printf("        setting_easy_canary = 0x%X,\n",             calc(mem.pc.settings, mem.pc.settings.easy_canary));
   printf("        setting_jiggy_requirements = 0x%X,\n",      calc(mem.pc.settings, mem.pc.settings.jiggy_requirements));
   printf("        setting_silo_requirements = 0x%X,\n",       calc(mem.pc.settings, mem.pc.settings.silo_requirements));
+  printf("        setting_green_relics_chamber_requirement = 0x%X,\n", calc(mem.pc.settings, mem.pc.settings.green_relics_chamber_requirement));
+  printf("        setting_green_relics_boss_requirement = 0x%X,\n",    calc(mem.pc.settings, mem.pc.settings.green_relics_boss_requirement));
   printf("    pc_items = 0x%X,\n",                            calc(ptr, ptr.pc_items));
   printf("    pc_traps = 0x%X,\n",                            calc(ptr, ptr.pc_traps));
   printf("    pc_exit_map = 0x%X,\n",                         calc(ptr, ptr.pc_exit_map));

--- a/pc/src/client/bt_client.cpp
+++ b/pc/src/client/bt_client.cpp
@@ -2044,12 +2044,12 @@ asio::awaitable<void> BTClient::getSlotData()
     if(block.contains(string{"slot_green_relics_chamber_requirement"}))
     {
         AP_GRRELICS_CHAMBER = block["slot_green_relics_chamber_requirement"];
-        if(DEBUG_NET == true) { std::cout << "Gren Relics Slightly Sacred Chamber Requirement is set to" << AP_GRRELICS_CHAMBER << std::endl; }
+        if(DEBUG_NET == true) { std::cout << "Green Relics Slightly Sacred Chamber Requirement is set to" << AP_GRRELICS_CHAMBER << std::endl; }
     }
     if(block.contains(string{"slot_green_relics_boss_requirement"}))
     {
         AP_GRRELICS_BOSS = block["slot_green_relics_boss_requirement"]
-        if(DEBUG_NET == true) { std::cout << "Gren Relics Boss Requirement is set to" << AP_GRRELICS_BOSS << std::endl; }
+        if(DEBUG_NET == true) { std::cout << "Green Relics Boss Requirement is set to" << AP_GRRELICS_BOSS << std::endl; }
     }
     if(block.contains(string{"slot_randomize_beans"}) && block["slot_randomize_beans"] != 0)
     {

--- a/pc/src/client/bt_client.cpp
+++ b/pc/src/client/bt_client.cpp
@@ -1194,6 +1194,14 @@ void BTClient::initialize_bt()
     {
         ap_memory.pc.settings.randomize_green_relics = 1;
     }
+    if(AP_GRRELICS_CHAMBER != 0)
+    {
+        ap_memory.pc.settings.green_relics_chamber_requirement = AP_GRRELICS_CHAMBER;
+    }
+    if(AP_GRRELICS_BOSS != 0)
+    {
+        ap_memory.pc.settings.green_relics_boss_requirement = AP_GRRELICS_BOSS;
+    }
     if(ENABLE_AP_BEANS == true)
     {
         ap_memory.pc.settings.randomize_beans = 1;
@@ -2032,6 +2040,16 @@ asio::awaitable<void> BTClient::getSlotData()
     {
         ENABLE_AP_GRRELICS = true;
         if(DEBUG_NET == true) { std::cout << "Randomize Green Relics are Enabled" << std::endl; }
+    }
+    if(block.contains(string{"slot_green_relics_chamber_requirement"}))
+    {
+        AP_GRRELICS_CHAMBER = block["slot_green_relics_chamber_requirement"];
+        if(DEBUG_NET == true) { std::cout << "Gren Relics Slightly Sacred Chamber Requirement is set to" << AP_GRRELICS_CHAMBER << std::endl; }
+    }
+    if(block.contains(string{"slot_green_relics_boss_requirement"}))
+    {
+        AP_GRRELICS_BOSS = block["slot_green_relics_boss_requirement"]
+        if(DEBUG_NET == true) { std::cout << "Gren Relics Boss Requirement is set to" << AP_GRRELICS_BOSS << std::endl; }
     }
     if(block.contains(string{"slot_randomize_beans"}) && block["slot_randomize_beans"] != 0)
     {

--- a/pc/src/client/bt_client.hpp
+++ b/pc/src/client/bt_client.hpp
@@ -70,6 +70,8 @@ private:
   bool ENABLE_AP_GRRELICS = false;
   bool ENABLE_AP_TICKETS = false;
   bool ENABLE_AP_BEANS = false;
+  int AP_GRRELICS_CHAMBER = 0;
+  int AP_GRRELICS_BOSS = 0;
   int GOAL_TYPE = 0;
   int MGH_LENGTH = 0; //Mini-game Mumbo Token Length
   int BH_LENGTH = 0; //Boss Token Length

--- a/shared/include/ap_memory/pc.h
+++ b/shared/include/ap_memory/pc.h
@@ -61,6 +61,8 @@ typedef struct {
     u8 easy_canary;
     u8 jiggy_requirements[11];
     u16 silo_requirements[24];
+    u8 green_relics_chamber_requirement;
+    u8 green_relics_boss_requirement;
   } settings;
   u8 items[AP_ITEM_MAX];
   u8 traps[AP_TRAP_MAX];


### PR DESCRIPTION
Adding this to settings, syncing the settings correctly and injecting the value in the immediate value that checks for whether the door should or should not exist on map load.

There are a few other checks in ROM that check for 10 and 20, but as far as I understand, these are being patched out, so this is fine.


Also tested manually.